### PR TITLE
chore: rename `set` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased] - ReleaseData
 
+- Rename `EventRingDequeuePointerRegister::set` to `EventRingDequeuePointerRegister::set_event_ring_dequeue_pointer`
+
 ## 0.1.0 - 2021-01-22
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 <!-- next-header -->
 
-## [Unreleased] - ReleaseData
+## [Unreleased] - ReleaseDate
 
 - Rename `EventRingDequeuePointerRegister::set` to `EventRingDequeuePointerRegister::set_event_ring_dequeue_pointer`
 

--- a/src/registers/runtime.rs
+++ b/src/registers/runtime.rs
@@ -43,7 +43,7 @@ impl EventRingDequeuePointerRegister {
     /// # Errors
     ///
     /// This method may return an [`Error::NotAligned`] error if the address is not 16 byte aligned.
-    pub fn set(&mut self, p: u64) -> Result<(), Error> {
+    pub fn set_event_ring_dequeue_pointer(&mut self, p: u64) -> Result<(), Error> {
         if p.trailing_zeros() >= 4 {
             self.0 = p;
             Ok(())


### PR DESCRIPTION
- chore: rename to `set_event_ring_dequeue_pointer`
- chore: add a changelog
- fix: typo

bors r+
