### PR TITLE
chore: disable to push from `cargo release`

### DIFF
--- a/release.toml
+++ b/release.toml
@@ -1,3 +1,4 @@
+disable-push = true
 pre-release-replacements = [
   {file="CHANGELOG.md", search="Unreleased", replace="{{version}}"},
   {file="CHANGELOG.md", search="\\.\\.\\.HEAD", replace="...{{tag_name}}", exactly=1},


### PR DESCRIPTION
The master branch is protected.

bors r+
