### PR TITLE
chore: add `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+edition = "2018"
+merge_imports = true


### PR DESCRIPTION
bors r+
