### PR TITLE
chore: edit `rustfmt.toml`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -2,3 +2,4 @@
 
 edition = "2018"
 merge_imports = true
+format_code_in_doc_comments = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,5 +1,3 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
-
 edition = "2018"
 merge_imports = true
 format_code_in_doc_comments = true


### PR DESCRIPTION
- chore: add `rustfmt.toml`
- chore: format doc comments
- fix: forgot to remove the license notation
