### PR TITLE
chore: reexport `error::Error` as `Error`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - ReleaseDate
 ### Added
-- Reexport `error::Error`.
+- Reexport `error::Error` as `Error`.
 
 ## 0.2.5 - 2021-01-23
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Added
+- Reexport `error::Error`.
 
 ## 0.2.5 - 2021-01-23
 ### Added

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![no_std]
 
+pub use error::Error;
+
 pub mod error;
 pub mod extended_capabilities;
 pub mod registers;


### PR DESCRIPTION
- chore: reexport `Error`
- chore: add a changelog
- chore: add a changelog

bors r+
