### PR TITLE
chore: use `imports_granularity`

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,3 @@
 edition = "2018"
-merge_imports = true
+imports_granularity = "Crate"
 format_code_in_doc_comments = true


### PR DESCRIPTION
bors r+
