### PR TITLE
chore: panics if it fails to create an accessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Changed
+- Methods of the `register` module now panic if it fails to create an accessor.
 
 ## 0.3.0 - 2021-01-31
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["no_std", "OS"]
 github = { repository = "toku-sa-n/xhci", workflow = "Rust" }
 
 [dependencies]
-accessor = "0.2.0"
+accessor = "0.3.0"
 bit_field = "0.10.1"
 num-derive = { version = "0.3.3", default-features = false }
 num-traits = { version = "0.2.14", default-features = false }

--- a/src/extended_capabilities/mod.rs
+++ b/src/extended_capabilities/mod.rs
@@ -138,9 +138,7 @@ where
         let current = self.current?;
 
         // SAFETY: `Iter::new` guarantees that `self.current` is the correct address.
-        let h: Header = unsafe { accessor::Single::new(current, self.m.clone()) }
-            .expect("The base address of the xHCI Extended Capability must be aligned correctly.")
-            .read();
+        let h: Header = unsafe { accessor::Single::new(current, self.m.clone()) }.read();
 
         self.current = if h.next() == 0 {
             None
@@ -151,9 +149,7 @@ where
         Some(match h.id() {
             // SAFETY: `List::new` ensures that the all necessary conditions are fulfilled.
             1 => Ok(ExtendedCapability::UsbLegacySupportCapability(unsafe {
-                accessor::Single::new(current, self.m.clone()).expect(
-                    "The base address of the xHCI Extended Capability must be aligned correctly.",
-                )
+                accessor::Single::new(current, self.m.clone())
             })),
             e => Err(NotSupportedId(e)),
         })

--- a/src/registers/capability.rs
+++ b/src/registers/capability.rs
@@ -33,28 +33,27 @@ where
     /// The caller must ensure that the Host Controller Capability Registers are accessed only
     /// through this struct.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return an [`accessor::Error::NotAligned`] error if `mmio_base` is not aligned
-    /// properly.
-    pub unsafe fn new(mmio_base: usize, mapper: &M) -> Result<Self, accessor::Error>
+    /// This method panics if `mmio_base` is not aligned correctly.
+    pub unsafe fn new(mmio_base: usize, mapper: &M) -> Self
     where
         M: Mapper,
     {
         macro_rules! m {
             ($offset:expr) => {
-                accessor::Single::new(mmio_base + $offset, mapper.clone())?
+                accessor::Single::new(mmio_base + $offset, mapper.clone())
             };
         }
 
-        Ok(Self {
+        Self {
             caplength: m!(0x00),
             hcsparams1: m!(0x04),
             hcsparams2: m!(0x08),
             hccparams1: m!(0x10),
             dboff: m!(0x14),
             rtsoff: m!(0x18),
-        })
+        }
     }
 }
 

--- a/src/registers/doorbell.rs
+++ b/src/registers/doorbell.rs
@@ -20,15 +20,14 @@ impl Register {
     /// Caller must ensure that the only one accessor is created, otherwise it may cause undefined
     /// behavior such as data race.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return a [`accessor::Error::NotAligned`] error if the start of the Doorbell
-    /// Array is not aligned.
+    /// This method panics if the base address of the Doorbell Array is not aligned correctly.
     pub unsafe fn new<M1, M2>(
         mmio_base: usize,
         capability: &Capability<M2>,
         mapper: M1,
-    ) -> Result<accessor::Array<Self, M1>, accessor::Error>
+    ) -> accessor::Array<Self, M1>
     where
         M1: Mapper,
         M2: Mapper + Clone,

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -37,10 +37,9 @@ where
     ///
     /// The caller must ensure that the xHCI registers are accessed only through this struct.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return a [`accessor::Error::NotAligned`] error if a base address of a
-    /// register is not aligned properly.
+    /// This method panics if `mmio_base` is not aligned correctly.
     ///
     /// # Examples
     ///
@@ -70,20 +69,20 @@ where
     ///         .expect("The base address of the MMIO space is not aligned correctly.")
     /// };
     /// ```
-    pub unsafe fn new(mmio_base: usize, mapper: M) -> Result<Self, accessor::Error> {
-        let capability = Capability::new(mmio_base, &mapper)?;
-        let doorbell = doorbell::Register::new(mmio_base, &capability, mapper.clone())?;
-        let operational = Operational::new(mmio_base, capability.caplength.read(), &mapper)?;
-        let port_register_set = PortRegisterSet::new(mmio_base, &capability, mapper.clone())?;
+    pub unsafe fn new(mmio_base: usize, mapper: M) -> Self {
+        let capability = Capability::new(mmio_base, &mapper);
+        let doorbell = doorbell::Register::new(mmio_base, &capability, mapper.clone());
+        let operational = Operational::new(mmio_base, capability.caplength.read(), &mapper);
+        let port_register_set = PortRegisterSet::new(mmio_base, &capability, mapper.clone());
         let interrupt_register_set =
-            InterruptRegisterSet::new(mmio_base, capability.rtsoff.read(), mapper)?;
+            InterruptRegisterSet::new(mmio_base, capability.rtsoff.read(), mapper);
 
-        Ok(Self {
+        Self {
             capability,
             doorbell,
             operational,
             port_register_set,
             interrupt_register_set,
-        })
+        }
     }
 }

--- a/src/registers/operational.rs
+++ b/src/registers/operational.rs
@@ -36,14 +36,11 @@ where
     /// The caller must ensure that the Host Controller Operational Registers are accessed only
     /// through this struct.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return an [`accessor::Error::NotAligned`] error if `mmio_base` is not aligned.
-    pub unsafe fn new(
-        mmio_base: usize,
-        caplength: CapabilityRegistersLength,
-        mapper: &M,
-    ) -> Result<Self, accessor::Error>
+    /// This method panics if the base address of the Host Controller Operational Registers are not
+    /// aligned correctly.
+    pub unsafe fn new(mmio_base: usize, caplength: CapabilityRegistersLength, mapper: &M) -> Self
     where
         M: Mapper,
     {
@@ -51,18 +48,18 @@ where
 
         macro_rules! m {
             ($offset:expr) => {
-                accessor::Single::new(base + $offset, mapper.clone())?
+                accessor::Single::new(base + $offset, mapper.clone())
             };
         }
 
-        Ok(Self {
+        Self {
             usbcmd: m!(0x00),
             usbsts: m!(0x04),
             pagesize: m!(0x08),
             crcr: m!(0x18),
             dcbaap: m!(0x30),
             config: m!(0x38),
-        })
+        }
     }
 }
 
@@ -249,15 +246,14 @@ impl PortRegisterSet {
     /// Caller must ensure that only one accessor is created, otherwise it may cause undefined
     /// behavior such as data race.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return a [`accessor::Error::NotAligned`] error if `mmio_base` is not
-    /// aligned properly.
+    /// This method panics if the base address of the Port Register Sets is not aligned correctly.
     pub unsafe fn new<M1, M2>(
         mmio_base: usize,
         capability: &Capability<M2>,
         mapper: M1,
-    ) -> Result<accessor::Array<Self, M1>, accessor::Error>
+    ) -> accessor::Array<Self, M1>
     where
         M1: Mapper,
         M2: Mapper + Clone,

--- a/src/registers/operational.rs
+++ b/src/registers/operational.rs
@@ -38,7 +38,7 @@ where
     ///
     /// # Panics
     ///
-    /// This method panics if the base address of the Host Controller Operational Registers are not
+    /// This method panics if the base address of the Host Controller Operational Registers is not
     /// aligned correctly.
     pub unsafe fn new(mmio_base: usize, caplength: CapabilityRegistersLength, mapper: &M) -> Self
     where

--- a/src/registers/runtime.rs
+++ b/src/registers/runtime.rs
@@ -26,15 +26,15 @@ impl InterruptRegisterSet {
     /// The caller must ensure that the Host Controller Runtime Registers are accessed only through
     /// this struct.
     ///
-    /// # Errors
+    /// # Panics
     ///
-    /// This method may return a [`accessor::Error::NotAligned`] error if the base address of the
-    /// Interrupt Register Set is not aligned.
+    /// This method panics if the base address of the Interrupt Register Sets is not aligned
+    /// correctly.
     pub unsafe fn new<M>(
         mmio_base: usize,
         rtoff: RuntimeRegisterSpaceOffset,
         mapper: M,
-    ) -> Result<accessor::Array<Self, M>, accessor::Error>
+    ) -> accessor::Array<Self, M>
     where
         M: Mapper,
     {


### PR DESCRIPTION
- chore: update the version of the `accessor` crate
- chore: panic immediately
