### PR TITLE
chore: deny the missing `Copy` implementations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings -D rustdoc -D missing_docs -D elided-lifetimes-in-paths -D explicit-outlives-requirements -D macro-use-extern-crate
+  RUSTFLAGS: -D warnings -D rustdoc -D missing_docs -D elided-lifetimes-in-paths -D explicit-outlives-requirements -D macro-use-extern-crate -D missing-copy-implementations
 
 jobs:
   build:


### PR DESCRIPTION
bors r+
