### PR TITLE
chore: deny missing `Debug` implementations

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings -D rustdoc -D missing_docs -D elided-lifetimes-in-paths -D explicit-outlives-requirements -D macro-use-extern-crate -D missing-copy-implementations -D meta-variable-misuse
+  RUSTFLAGS: -D warnings -D rustdoc -D missing_docs -D elided-lifetimes-in-paths -D explicit-outlives-requirements -D macro-use-extern-crate -D missing-copy-implementations -D meta-variable-misuse -D missing-debug-implementations
 
 
 jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased - ReleaseDate
 ### Added
-- All types now implements the `Debug` trait.
+- All types now implement the `Debug` trait.
 
 ### Fixed
 - Wrong codes in documentations are fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+### Added
+- All types now implements the `Debug` trait.
+
 ### Fixed
 - Wrong codes in documentations are fixed.
 

--- a/src/extended_capabilities/mod.rs
+++ b/src/extended_capabilities/mod.rs
@@ -62,6 +62,7 @@ pub use usb_legacy_support_capability::UsbLegacySupportCapability;
 pub mod usb_legacy_support_capability;
 
 /// A struct to access xHCI Extended Capabilities.
+#[derive(Debug)]
 pub struct List<M>
 where
     M: Mapper + Clone,
@@ -109,6 +110,7 @@ where
 }
 
 /// An iterator over the xHCI Extended Capability.
+#[derive(Debug)]
 pub struct IterMut<M>
 where
     M: Mapper + Clone,

--- a/src/registers/capability.rs
+++ b/src/registers/capability.rs
@@ -5,6 +5,7 @@ use bit_field::BitField;
 use core::{convert::TryInto, fmt};
 
 /// Host Controller Capability Registers
+#[derive(Debug)]
 pub struct Capability<M>
 where
     M: Mapper + Clone,

--- a/src/registers/mod.rs
+++ b/src/registers/mod.rs
@@ -12,6 +12,7 @@ pub mod operational;
 pub mod runtime;
 
 /// The access point to xHCI registers.
+#[derive(Debug)]
 pub struct Registers<M>
 where
     M: Mapper + Clone,

--- a/src/registers/operational.rs
+++ b/src/registers/operational.rs
@@ -8,6 +8,7 @@ use core::{convert::TryInto, fmt};
 /// Host Controller Operational Registers
 ///
 /// This struct does not contain the Port Register set.
+#[derive(Debug)]
 pub struct Operational<M>
 where
     M: Mapper + Clone,


### PR DESCRIPTION
bors r+
