### PR TITLE
chore: write the list of lints in `lib.rs`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on: [push, pull_request]
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings -D rustdoc -D missing_docs -D elided-lifetimes-in-paths -D explicit-outlives-requirements -D macro-use-extern-crate -D missing-copy-implementations -D meta-variable-misuse -D missing-debug-implementations
 
 
 jobs:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,17 @@
 //! A library which is useful to handle xHCI.
 
 #![no_std]
+#![deny(
+    warnings,
+    rustdoc,
+    missing_docs,
+    elided_lifetimes_in_paths,
+    explicit_outlives_requirements,
+    macro_use_extern_crate,
+    missing_copy_implementations,
+    meta_variable_misuse,
+    missing_debug_implementations
+)]
 
 pub use accessor;
 pub use extended_capabilities::ExtendedCapability;


### PR DESCRIPTION
rustdoc does not use `RUSTFLAGS` variable. It only accepts the attribute
style.

bors r+
