### PR TITLE
chore: release the version 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+
+## 0.4.1 - 2021-02-05
 ### Added
 - All types now implement the `Debug` trait.
 - Code examples are added.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xhci"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Hiroki Tokunaga <tokusan441@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -5,6 +5,19 @@
 
 # xhci
 
-A library which is useful to handle xHCI.
+A library to handle xHCI.
 
-License: MIT OR Apache-2.0
+This crate provides types of the xHCI structures, such as the Registers and Contexts.
+Users can use this library to implement a USB device deriver on your own OS.
+
+This crate is `#![no_std]` compatible.
+
+# Examples
+
+```no_run
+let mut r = unsafe { xhci::Registers::new(MMIO_BASE, mapper) };
+let o = &mut r.operational;
+
+o.usbcmd.update(|u| u.set_run_stop(true));
+while o.usbsts.read().hc_halted() {}
+```


### PR DESCRIPTION
- chore: bump the version to 0.4.1
- fix: forgot to update the `README.md`

bors r+
