### PR TITLE
chore: deny non-ascii idents

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
     macro_use_extern_crate,
     missing_copy_implementations,
     meta_variable_misuse,
+    non_ascii_idents,
     missing_debug_implementations
 )]
 


### PR DESCRIPTION
bors r+
