### PR TITLE
chore: deny the pointer structural match

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@
     missing_copy_implementations,
     meta_variable_misuse,
     non_ascii_idents,
+    pointer_structural_match,
     missing_debug_implementations
 )]
 


### PR DESCRIPTION
bors r+
