### PR TITLE
chore: deny the unused crate dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
     single_use_lifetimes,
     unaligned_references,
     unreachable_pub,
+    unused_crate_dependencies,
     trivial_casts,
     pointer_structural_match,
     missing_debug_implementations


### PR DESCRIPTION
bors r+
