### PR TITLE
chore: deny the unused extern crates

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
     unaligned_references,
     unreachable_pub,
     unused_crate_dependencies,
+    unused_extern_crates,
     trivial_casts,
     pointer_structural_match,
     missing_debug_implementations


### PR DESCRIPTION
bors r+
