### PR TITLE
chore: deny the unused import braces

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,7 @@
     unused_crate_dependencies,
     unused_extern_crates,
     trivial_casts,
+    unused_import_braces,
     pointer_structural_match,
     missing_debug_implementations
 )]


### PR DESCRIPTION
bors r+
