### PR TITLE
chore: deny the unused lifetimes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@
     unused_extern_crates,
     trivial_casts,
     unused_import_braces,
+    unused_lifetimes,
     pointer_structural_match,
     missing_debug_implementations
 )]


### PR DESCRIPTION
bors r+
