### PR TITLE
chore: bump the version to 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased - ReleaseDate
+
+## 0.5.2 - 2021-02-25
 ### Added
 - `From` trait is implemented for the `Allowed` enum to convert from the structs of TRBs to the enum.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xhci"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Hiroki Tokunaga <tokusan441@gmail.com>"]
 edition = "2018"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
bors r+
